### PR TITLE
ログイン後、httpリクエストによりidが発行され、infra/app_user_service.dart にアプリIDが保存されるように…

### DIFF
--- a/lib/app/infra/app_user_service.dart
+++ b/lib/app/infra/app_user_service.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class AppUserService {
+  static const String baseUrl = "https://fccapi.ddns.net";
+
+  // シングルトン風にアプリ全体で管理
+  static String? _appId;
+
+  /// サーバーにユーザーデータを送信し、idを保持する
+  static Future<void> sendUserData(String name, String lineUserId) async {
+    final payload = {
+      "name": name,
+      "line_user_id": lineUserId,
+    };
+
+    final response = await http.post(
+      Uri.parse("$baseUrl/get_id"),
+      headers: {"Content-Type": "application/json"},
+      body: jsonEncode(payload),
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      _appId = data["id"].toString(); // サーバーから返るidを保持
+      // print("取得したid: $_appId");
+    } else {
+      throw Exception("エラー: ${response.statusCode} ${response.body}");
+    }
+  }
+
+  /// idを取得する
+  static String? getAppId() => _appId;
+
+  /// ログアウト時にリセット
+  static void resetAppId() {
+    _appId = null;
+  }
+}

--- a/lib/app/ui/home/home_ui_auth_provider.dart
+++ b/lib/app/ui/home/home_ui_auth_provider.dart
@@ -1,6 +1,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:flutter_line_sdk/flutter_line_sdk.dart';
 import 'home_ui_state.dart';
+import '../../infra/app_user_service.dart';
 
 part 'home_ui_auth_provider.g.dart';
 
@@ -27,15 +28,16 @@ class HomeUiAuth extends _$HomeUiAuth {
     try {
       final result = await LineSDK.instance.login();
       final profile = result.userProfile;
-      // final displayName = profile.displayName;
-      // final pictureUrl = profile.pictureUrl;
-      print("ログイン成功: ${result.userProfile?.displayName}");
+      final userId = profile?.userId;
+      final displayName = profile?.displayName;
+      print("ログイン成功: ${displayName}");
       state = state.copyWith(
         isLoggedIn: true,
         pictureUrl: profile?.pictureUrl,
       );
-      // -------------ToDo-------------
-      // httpリクエストでIDを取得(https://fccapi.ddns.net/get_id)
+      await AppUserService.sendUserData(displayName ?? "不明", userId ?? "");  // 要検討
+      // final appId = AppUserService.getAppId();
+      // print("現在のappId: $appId");
     } catch (e) {
       print("ログイン失敗: $e");
       state = state.copyWith(isLoggedIn: false, pictureUrl: null);
@@ -47,6 +49,7 @@ class HomeUiAuth extends _$HomeUiAuth {
       await LineSDK.instance.logout();
       print("ログアウト成功");
       state = state.copyWith(isLoggedIn: false);
+      AppUserService.resetAppId();
     } catch (e) {
       print("ログアウト失敗: $e");
     }


### PR DESCRIPTION
…なりました。
もし同じ人がログインしてきた場合、前に発行したidが返ってくることも確認しました。
(1),(2)はこれで完成です。